### PR TITLE
Adds explicit imported Redis class names

### DIFF
--- a/redisearch/auto_complete.py
+++ b/redisearch/auto_complete.py
@@ -1,4 +1,4 @@
-import redis
+from redis import Redis, ConnectionPool
 
 class Suggestion(object):
     """


### PR DESCRIPTION
Without this, trying to create a new AutoCompleter w/o passing the connection argument errors as follows:

```
Traceback (most recent call last):
...
    ac = AutoCompleter('wsac')
  File "redacted/redisearch/auto_complete.py", line 40, in __init__
    self.redis = conn if conn is not None else Redis(
NameError: global name 'Redis' is not defined
```