### PR TITLE
Fixed import issues caused by python3 compatibility's _util.py

### DIFF
--- a/_util.py
+++ b/_util.py
@@ -1,9 +1,0 @@
-import six
-
-def to_string(s):
-    if isinstance(s, six.string_types):
-        return s
-    elif isinstance(s, bytes):
-        return s.decode('utf-8')
-    else:
-        return s  # Not a string we care about

--- a/redisearch/_util.py
+++ b/redisearch/_util.py
@@ -1,0 +1,9 @@
+import six
+
+def to_string(s):
+    if isinstance(s, six.string_types):
+        return s
+    elif isinstance(s, bytes):
+        return s.decode('utf-8')
+    else:
+        return s  # Not a string we care about

--- a/redisearch/auto_complete.py
+++ b/redisearch/auto_complete.py
@@ -1,7 +1,7 @@
 from redis import Redis, ConnectionPool
 from six.moves import xrange
 
-from _util import to_string
+from ._util import to_string
 
 class Suggestion(object):
     """

--- a/redisearch/client.py
+++ b/redisearch/client.py
@@ -7,7 +7,7 @@ from six.moves import zip
 from .document import Document
 from .result import Result
 from .query import Query, Filter
-from _util import to_string
+from ._util import to_string
 
 
 class Field(object):

--- a/redisearch/result.py
+++ b/redisearch/result.py
@@ -1,7 +1,7 @@
 from six.moves import xrange, zip as izip
 
 from .document import Document
-from _util import to_string
+from ._util import to_string
 
 class Result(object):
     """


### PR DESCRIPTION
Python3 support (I haven't tested it in Python 2) in master was encountering import issues with _util.py. I moved it into the redisearch folder and changed all the imports to relative imports, fixing the issue and cleaning up the repo a tiny tiny bit. It now imports properly for me. Hopefully this helps with supporting both versions!